### PR TITLE
Fix building on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: ldid
 	$(CXX) $(CFLAGS) $(CXXFLAGS) -std=c++11 -o $@ -c $^ -I.
 
 ldid: $(LDID_OBJS)
-	$(CXX) $(CFLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ $^
+	$(CXX) $(CFLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 clean:
 	rm -f $(LDID_OBJS)


### PR DESCRIPTION
Order of arguments matters to binutils ld.